### PR TITLE
Feature/secure hash

### DIFF
--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -170,8 +170,7 @@ class PasswordResetter
 
         $login = $user['login'];
 
-        $keySuffix = time() . Common::getRandomString($length = 32);
-        $token = $this->generatePasswordResetToken($user, $keySuffix);
+        $token = $this->generatePasswordResetToken($user);
         $this->savePasswordResetInfo($login, $newPassword, $token);
 
         // ... send email with confirmation link
@@ -270,7 +269,7 @@ class PasswordResetter
      *                                  the current timestamp.
      * @return string The generated token.
      */
-    public function generatePasswordResetToken($user, $keySuffix, $expiryTimestamp = null)
+    public function generatePasswordResetToken($user, $expiryTimestamp = null)
     {
         /*
          * Piwik does not store the generated password reset token.
@@ -282,7 +281,7 @@ class PasswordResetter
 
         $expiry = strftime('%Y%m%d%H', $expiryTimestamp);
         $token = $this->generateSecureHash(
-            $expiry . $user['login'] . $user['email'] . $user['ts_password_modified'] . $keySuffix,
+            $expiry . $user['login'] . $user['email'] . $user['ts_password_modified'],
             $user['password']
         );
         return $token;

--- a/plugins/Login/tests/Integration/PasswordResetterTest.php
+++ b/plugins/Login/tests/Integration/PasswordResetterTest.php
@@ -195,7 +195,7 @@ class PasswordResetterTest extends IntegrationTestCase
                 ['Test.Mail.send', \DI\value(function (PHPMailer $mail) {
                     $body = $mail->createBody();
                     $body = preg_replace("/=[\r\n]+/", '', $body);
-                    preg_match('/resetToken=[\s]*3D([a-zA-Z0-9=\s]+)<\/p>/', $body, $matches);
+                    preg_match('/resetToken=[\s]*3D([a-zA-Z0-9=%$\s]+)<\/p>/', $body, $matches);
                     if (!empty($matches[1])) {
                         $capturedToken = $matches[1];
                         $capturedToken = preg_replace('/=\s*/', '', $capturedToken);


### PR DESCRIPTION
As the different hash algorithm can return different hashes for the same input, it not feasible or predictable to not save the token in the database, so:

1. Key suffix has been removed
2. new token is saved in the reset record
3. PasswordResetter adjusted to reflect the new changes.